### PR TITLE
Bugfix for double connect code path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,59 @@
 {
     "name": "chronicle-consumer",
-    "version": "0.0.1",
-    "lockfileVersion": 1,
+    "version": "0.0.2",
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "chronicle-consumer",
+            "version": "0.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "emittery": "^0.5.1",
+                "ws": "^7.4.6"
+            },
+            "devDependencies": {
+                "commander": "^2.19.0"
+            },
+            "engines": {
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
+        "node_modules/emittery": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.5.1.tgz",
+            "integrity": "sha512-sYZXNHH9PhTfs98ROEFVC3bLiR8KSqXQsEHIwZ9J6H0RaQObC3JYq4G8IvDd0b45/LxfGKYBpmaUN4LiKytaNw==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ws": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        }
+    },
     "dependencies": {
         "commander": {
             "version": "2.20.3",
@@ -10,10 +61,16 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
+        "emittery": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.5.1.tgz",
+            "integrity": "sha512-sYZXNHH9PhTfs98ROEFVC3bLiR8KSqXQsEHIwZ9J6H0RaQObC3JYq4G8IvDd0b45/LxfGKYBpmaUN4LiKytaNw=="
+        },
         "ws": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
-            "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "requires": {}
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "node": ">= 0.12.0"
     },
     "dependencies": {
-        "ws": "^7.2.1",
-        "emittery": "^0.5.1"
+        "emittery": "^0.5.1",
+        "ws": "^7.4.6"
     },
     "devDependencies": {
         "commander": "^2.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chronicle-consumer",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Consumer module for EOSIO Chronicle",
     "license": "MIT",
     "author": "cc32d9 (https://github.com/cc32d9)",

--- a/src/index.js
+++ b/src/index.js
@@ -94,8 +94,8 @@ class ConsumerServer {
       } catch (err) {
         console.error('Graceful close of websocket threw error', err);
       } finally {
-        this['kConsumerServerClientConnected'] = false;
         if (emitDisconnect) {
+          this['kConsumerServerClientConnected'] = false;
           this.emitter.emit('disconnected', {remoteAddress: socket._socket.remoteAddress,
             remoteFamily: socket._socket.remoteFamily,
             remotePort: socket._socket.remotePort});


### PR DESCRIPTION
`WebSocket.abortHandshake` is not an exported function, so that when this line on original line 94 was hit, the code would crash.

This changes the code path to try a graceful close of the socket, and uses try/catch/finally to ensure that we always clean up state for graceful closes as well as error disconnects.